### PR TITLE
fix(proxy): forward content-frame API calls + errors to chrome shell

### DIFF
--- a/internal/proxy/bridge_live_test.go
+++ b/internal/proxy/bridge_live_test.go
@@ -1,0 +1,155 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	chromedp "github.com/chromedp/chromedp"
+)
+
+// TestContentToShellBridge_Live is an opt-in end-to-end check that content-frame
+// fetch/XHR calls and JS/console errors are forwarded up to the chrome shell, so
+// the indicator (which runs in the shell window) sees them. Gated on
+// AGNT_LIVE_BRIDGE because it launches a real Chrome.
+//
+//	AGNT_LIVE_BRIDGE=1 go test ./internal/proxy -run TestContentToShellBridge_Live -v
+func TestContentToShellBridge_Live(t *testing.T) {
+	if os.Getenv("AGNT_LIVE_BRIDGE") == "" {
+		t.Skip("set AGNT_LIVE_BRIDGE=1 to run the live browser bridge check")
+	}
+
+	// Backend app: a full HTML document (so the proxy applies the always-wrap
+	// shell model) that on load issues a fetch, logs a console error, and throws
+	// an uncaught error.
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/data" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<!DOCTYPE html><html><head><title>app</title></head><body>
+<h1>app</h1>
+<script>
+  fetch('/api/data').then(function(r){return r.json();}).catch(function(){});
+  console.error('CERR_MARKER');
+  setTimeout(function(){ throw new Error('JSERR_MARKER'); }, 50);
+</script>
+</body></html>`))
+	}))
+	defer backend.Close()
+
+	ps, err := NewProxyServer(ProxyConfig{
+		ID:         "live-bridge",
+		TargetURL:  backend.URL,
+		ListenPort: 0, // auto-assign
+	})
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := ps.Start(ctx); err != nil {
+		t.Fatalf("proxy Start: %v", err)
+	}
+	defer ps.Stop(context.Background())
+
+	proxyURL := "http://" + ps.ListenAddr + "/"
+
+	// Wait for the proxy to serve.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, e := http.Get(proxyURL)
+		if e == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Launch Chrome.
+	execPath := os.Getenv("AGNT_CHROME")
+	if execPath == "" {
+		execPath = "google-chrome"
+	}
+	allocOpts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.ExecPath(execPath),
+		chromedp.Headless,
+		chromedp.DisableGPU,
+		chromedp.Flag("disable-dev-shm-usage", true),
+		chromedp.NoFirstRun,
+		chromedp.NoDefaultBrowserCheck,
+	)
+	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), allocOpts...)
+	defer allocCancel()
+	bctx, bcancel := chromedp.NewContext(allocCtx)
+	defer bcancel()
+	runCtx, runCancel := context.WithTimeout(bctx, 30*time.Second)
+	defer runCancel()
+
+	// Evaluate in the TOP (shell) frame: read the shell's own buffers, which are
+	// only non-empty if the content frame forwarded its captures up.
+	var raw string
+	expr := `(function(){
+	  if(!window.__devtool_api||!window.__devtool_errors){return 'NO_API role='+(window.__devtool_frame_role||'?');}
+	  var calls=window.__devtool_api.getCalls();
+	  return JSON.stringify({
+	    role: window.__devtool_frame_role||'?',
+	    urls: calls.map(function(c){return c.url;}),
+	    stats: window.__devtool_errors.getStats()
+	  });
+	})()`
+
+	if err := chromedp.Run(runCtx,
+		chromedp.Navigate(proxyURL),
+		chromedp.Sleep(3*time.Second),
+		chromedp.Evaluate(expr, &raw),
+	); err != nil {
+		t.Fatalf("chromedp run: %v", err)
+	}
+
+	t.Logf("shell-frame state: %s", raw)
+
+	if strings.HasPrefix(raw, "NO_API") {
+		t.Fatalf("shell frame had no devtool API: %s", raw)
+	}
+
+	var got struct {
+		Role  string   `json:"role"`
+		URLs  []string `json:"urls"`
+		Stats struct {
+			JSErrorCount      int `json:"jsErrorCount"`
+			ConsoleErrorCount int `json:"consoleErrorCount"`
+			TotalCount        int `json:"totalCount"`
+		} `json:"stats"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", raw, err)
+	}
+
+	if got.Role != "chrome" {
+		t.Errorf("top frame role = %q, want chrome (proxy not applying shell wrap?)", got.Role)
+	}
+
+	var sawAPI bool
+	for _, u := range got.URLs {
+		if strings.Contains(u, "/api/data") {
+			sawAPI = true
+		}
+	}
+	if !sawAPI {
+		t.Errorf("shell Network buffer missing /api/data; urls=%v", got.URLs)
+	}
+	if got.Stats.JSErrorCount < 1 {
+		t.Errorf("shell Errors buffer missing JS error; stats=%+v", got.Stats)
+	}
+	if got.Stats.ConsoleErrorCount < 1 {
+		t.Errorf("shell Errors buffer missing console error; stats=%+v", got.Stats)
+	}
+}

--- a/internal/proxy/scripts/api-tracker.js
+++ b/internal/proxy/scripts/api-tracker.js
@@ -20,6 +20,20 @@
     if (callBuffer.length > MAX_ENTRIES) {
       callBuffer.shift();
     }
+    // The proxy renders a top-level navigation as a chrome shell wrapping the
+    // real page in a content <iframe>. The indicator UI runs in the shell, but
+    // fetch/XHR happen in the content frame — so the shell's own buffer is
+    // empty. Forward each captured call up to the shell (same-origin direct
+    // reach; the proxy serves both frames) so its Network tab + badge update.
+    // Best-effort; never let a forwarding failure break capture.
+    if (window.__devtool_frame_role === 'content') {
+      try {
+        var shell = window.parent;
+        if (shell && shell !== window && typeof shell.__devtool_api_ingest === 'function') {
+          shell.__devtool_api_ingest(call);
+        }
+      } catch (e) { /* cross-origin / shell gone */ }
+    }
   }
 
   /**
@@ -79,7 +93,7 @@
             } catch (e) {}
           }).catch(function() {});
         }
-        addCall(call);
+        if (window.__devtool_frame_role !== 'chrome') { addCall(call); }
         return response;
       })
       .catch(function(error) {
@@ -87,7 +101,7 @@
         call.ok = false;
         call.duration = Date.now() - startTime;
         call.error = error.message || 'Network error';
-        addCall(call);
+        if (window.__devtool_frame_role !== 'chrome') { addCall(call); }
         throw error;
       });
   };
@@ -135,7 +149,7 @@
           } catch (e) {}
         } catch (e) {}
       }
-      addCall(call);
+      if (window.__devtool_frame_role !== 'chrome') { addCall(call); }
     };
 
     xhr.addEventListener('loadend', onLoadEnd);
@@ -341,6 +355,19 @@
     }
     return { buckets: buckets, window: windowSec, maxBucket: maxBucket };
   }
+
+  // Shell-side ingest: content frames forward their captured calls here (see
+  // addCall) because the indicator runs in the chrome shell — a separate window
+  // from the content frame where fetch/XHR actually happen. Terminal sink: does
+  // not re-forward (the shell has no parent shell), so no loop. Defined in every
+  // frame for simplicity; only ever invoked on the shell by its content child.
+  window.__devtool_api_ingest = function(call) {
+    if (!call) { return; }
+    callBuffer.push(call);
+    if (callBuffer.length > MAX_ENTRIES) {
+      callBuffer.shift();
+    }
+  };
 
   // Export API
   window.__devtool_api = {

--- a/internal/proxy/scripts/core.js
+++ b/internal/proxy/scripts/core.js
@@ -558,6 +558,33 @@
     var consoleErrorBuffer = [];
     var consoleWarningBuffer = [];
 
+    // The proxy wraps a top-level navigation in a chrome shell whose body is a
+    // content <iframe> with the real page. Error capture (setupErrorTrackingWith
+    // Buffer) runs only in the content frame, but the indicator's Errors tab
+    // reads window.__devtool_errors in the SHELL — a separate window. Forward
+    // each buffered error up to the shell (same-origin direct reach; the proxy
+    // serves both frames) so the shell's buffers, and thus the Errors tab +
+    // badge, reflect the page. kind is 'js' | 'console' | 'warning'.
+    function forwardErrorToShell(kind, entry) {
+      if (window.__devtool_frame_role !== 'content') { return; }
+      try {
+        var shell = window.parent;
+        if (shell && shell !== window && typeof shell.__devtool_errors_ingest === 'function') {
+          shell.__devtool_errors_ingest(kind, entry);
+        }
+      } catch (e) { /* cross-origin / shell gone — best-effort */ }
+    }
+
+    // Shell-side sink for errors forwarded by content frames. Terminal: pushes
+    // into the shell's own buffers (does not re-forward), so getDeduplicatedErr-
+    // ors / getStats / the Errors tab all see content-frame errors unchanged.
+    function ingestForwardedError(kind, entry) {
+      if (!entry) { return; }
+      if (kind === 'js') { addToBuffer(jsErrorBuffer, entry); }
+      else if (kind === 'console') { addToBuffer(consoleErrorBuffer, entry); }
+      else if (kind === 'warning') { addToBuffer(consoleWarningBuffer, entry); }
+    }
+
     // Consolidated error stream - combines errors from all sources
     // Sources: proxy (server-side errors), js (JavaScript errors), console (console.error),
     //          http (HTTP errors like 4xx/5xx), process (stdout/stderr from processes)
@@ -686,6 +713,7 @@
             };
 
             addToBuffer(consoleErrorBuffer, entry);
+            forwardErrorToShell('console', entry);
 
             // Add to consolidated error stream
             addConsolidatedError({
@@ -738,6 +766,7 @@
             };
 
             addToBuffer(consoleWarningBuffer, entry);
+            forwardErrorToShell('warning', entry);
 
             // Add to consolidated error stream
             addConsolidatedError({
@@ -798,6 +827,7 @@
             };
 
             addToBuffer(jsErrorBuffer, entry);
+            forwardErrorToShell('js', entry);
 
             // Add to consolidated error stream
             addConsolidatedError({
@@ -1268,6 +1298,11 @@
 
     // Export error tracking API for diagnostics panel
     try {
+      // Shell-side ingest sink for errors forwarded by content frames. Exported
+      // unconditionally (every frame) — only the shell is ever called, by its
+      // content child via window.parent.__devtool_errors_ingest. See
+      // forwardErrorToShell / ingestForwardedError above.
+      window.__devtool_errors_ingest = ingestForwardedError;
       if (!window.__devtool_errors) {
         window.__devtool_errors = {
           getJSErrors: function() {

--- a/internal/proxy/scripts/core.js
+++ b/internal/proxy/scripts/core.js
@@ -576,8 +576,11 @@
     }
 
     // Shell-side sink for errors forwarded by content frames. Terminal: pushes
-    // into the shell's own buffers (does not re-forward), so getDeduplicatedErr-
-    // ors / getStats / the Errors tab all see content-frame errors unchanged.
+    // into the shell's own per-kind buffers (does not re-forward), so getDedup-
+    // licatedErrors / getStats / the Errors tab all see content-frame errors
+    // unchanged. Deliberately does NOT feed the consolidated stream
+    // (addConsolidatedError) — no shell-side consumer reads getConsolidated*
+    // today. If one is added, forwarded errors must also land there.
     function ingestForwardedError(kind, entry) {
       if (!entry) { return; }
       if (kind === 'js') { addToBuffer(jsErrorBuffer, entry); }


### PR DESCRIPTION
## Problem

The proxy UI tabs (**Network**, **Errors**) and their badges stopped updating with the page's real API calls and front-end errors.

Root cause: the always-wrap shell model (`injector.go` `BuildShellDocument`, default for top-level navigations) renders a page as a **chrome shell** wrapping the real page in a content `<iframe>`. The indicator UI runs in the **shell** frame, but:

- `api-tracker.js` wraps `fetch`/XHR per-frame → app calls land in the **content** frame's `callBuffer`.
- `core.js` error capture runs **only in the content frame** (`__isContent` gate at init) → JS/console errors land in the **content** frame's buffers.

The shell's own buffers stayed empty, so `getCalls()` / `getDeduplicatedErrors()` / `getStats()` — which feed the tabs + badges via the 1s poll — saw nothing.

## Fix

Content frames forward each captured call/error up to the shell via the existing same-origin cross-frame idiom (`frames.js` `window.parent.__devtool_*`):

- `api-tracker.js` — `addCall` forwards to `shell.__devtool_api_ingest` when `role==='content'`; new terminal ingest sink; chrome stops recording its own WS/screenshot fetches as Network noise.
- `core.js` — `forwardErrorToShell` + `ingestForwardedError`; forward at the js/console/warn buffer pushes; `window.__devtool_errors_ingest` export.

Shell ingest pushes into the shell's own buffers, so `getCalls` / `getDeduplicatedErrors` / `getStats` / audits all work unchanged. No loop (shell is terminal). **Backward compatible** — standalone (no-shell) pages keep local capture; forward is gated on `role==='content'`.

## Verification

Opt-in headless-Chrome regression test (`bridge_live_test.go`, `AGNT_LIVE_BRIDGE=1`). A content-frame fetch + uncaught throw + `console.error` all surface in the shell frame:

```json
{"role":"chrome","urls":["…/api/data"],"stats":{"jsErrorCount":1,"consoleErrorCount":1,"totalCount":2}}
```

Normal suite green (`go test ./internal/proxy/...`); live test skips unless gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)